### PR TITLE
Add extraction tests with mocked APIs

### DIFF
--- a/extraction.py
+++ b/extraction.py
@@ -1,0 +1,167 @@
+import os
+import json
+try:
+    import requests
+except Exception:  # pragma: no cover - optional dependency
+    requests = None
+
+fields = [
+    "title", "author", "year", "doi",
+    "author_keywords", "country", "source_journal", "study_type"
+]
+
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+llm_model = "gpt-4"
+
+
+def normalize_doi(doi: str) -> str:
+    if not doi:
+        return ""
+    doi = str(doi).strip().lower()
+    if doi.startswith("https://doi.org/"):
+        doi = doi[len("https://doi.org/"):]
+    return doi
+
+
+def clean_str(txt: str) -> str:
+    return "".join(c for c in str(txt or "").lower() if c.isalnum() or c.isspace()).replace(" ", "")
+
+
+def approx_match(a: str, b: str, field: str) -> bool:
+    if a is None or b is None:
+        return False
+    if field == "doi":
+        return normalize_doi(a) == normalize_doi(b)
+    if field in ["author_keywords"]:
+        sa = sorted({x.strip() for x in str(a).replace(";", " ").replace(",", " ").lower().split() if x})
+        sb = sorted({x.strip() for x in str(b).replace(";", " ").replace(",", " ").lower().split() if x})
+        return sa == sb
+    return clean_str(a) == clean_str(b)
+
+
+def extract_crossref_full(doi: str, title: str | None = None) -> dict:
+    meta = {f: "" for f in fields}
+    try:
+        url = f"https://api.crossref.org/works/{normalize_doi(doi)}" if doi else None
+        if url:
+            r = requests.get(url)
+            dat = r.json()["message"]
+        elif title:
+            r = requests.get(f"https://api.crossref.org/works?query.title={title}&rows=1")
+            items = r.json()["message"].get("items", [])
+            dat = items[0] if items else {}
+        else:
+            dat = {}
+        meta["doi"] = normalize_doi(dat.get("DOI", ""))
+        meta["title"] = dat.get("title", [""])[0]
+        if dat.get("author"):
+            meta["author"] = "; ".join(
+                "{}, {}".format(a.get("family", "").strip(), a.get("given", "").strip())
+                for a in dat.get("author")
+            )
+            meta["country"] = "; ".join(
+                aff.get("name", "")
+                for a in dat["author"]
+                for aff in a.get("affiliation", [])
+            ).strip()
+        meta["year"] = str(dat.get("issued", {}).get("date-parts", [[None]])[0][0]) if dat.get("issued") else ""
+        meta["author_keywords"] = ";".join(dat.get("subject", [])) if dat.get("subject") else ""
+        meta["source_journal"] = dat.get("container-title", [""])[0] if dat.get("container-title") else ""
+        meta["study_type"] = dat.get("type", "")
+    except Exception:
+        pass
+    return meta
+
+
+def extract_openalex_full(doi: str, title: str | None = None) -> dict:
+    meta = {f: "" for f in fields}
+    try:
+        url = (
+            f"https://api.openalex.org/works/https://doi.org/{normalize_doi(doi)}"
+            if doi
+            else None
+        )
+        if url:
+            r = requests.get(url)
+            dat = r.json()
+        elif title:
+            url = f"https://api.openalex.org/works?title.search={title}"
+            r = requests.get(url)
+            dat = r.json().get("results", [{}])[0] if "results" in r.json() else r.json()
+        else:
+            dat = {}
+        doi_val = dat.get("doi", "")
+        if doi_val.startswith("https://doi.org/"):
+            doi_val = doi_val[len("https://doi.org/") :]
+        meta["doi"] = normalize_doi(doi_val)
+        meta["title"] = dat.get("title", "")
+        meta["author"] = "; ".join(
+            a.get("author", {}).get("display_name", "") for a in dat.get("authorships", [])
+        )
+        meta["year"] = str(dat.get("publication_year", ""))
+        meta["author_keywords"] = ";".join(dat.get("keywords", [])) if dat.get("keywords") else ""
+        meta["source_journal"] = dat.get("host_venue", {}).get("display_name", "") if dat.get("host_venue") else ""
+        meta["study_type"] = dat.get("type", "")
+        meta["country"] = "; ".join(
+            inst.get("country_code", "")
+            for auth in dat.get("authorships", [])
+            for inst in auth.get("institutions", [])
+        )
+    except Exception:
+        pass
+    return meta
+
+
+def extract_ai_llm_doi_only(first_page: str, api_key: str | None = None, model: str | None = None) -> str:
+    api_key = api_key or OPENAI_API_KEY
+    prompt = (
+        "Extract only the DOI (Digital Object Identifier) from the following text. If none is found, return an empty JSON.\n"
+        f"Text:\n{first_page}"
+    )
+    if not api_key:
+        return ""
+    try:
+        import openai
+
+        resp = openai.chat.completions.create(
+            model=model or llm_model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+            max_tokens=24,
+        )
+        txt = resp.choices[0].message.content.strip()
+        if txt.startswith("```"):
+            txt = txt.strip("` \n")
+            txt = txt[4:].strip() if txt.startswith("json") else txt
+        result = json.loads(txt)
+        return result.get("doi", "") if isinstance(result, dict) else result
+    except Exception:
+        return ""
+
+
+def extract_ai_llm_full(first_page: str, api_key: str | None = None, model: str | None = None) -> dict:
+    api_key = api_key or OPENAI_API_KEY
+    prompt = (
+        "Extract the following metadata as a JSON object from the text provided: title, author, year, doi, "
+        "author_keywords, country, source_journal, study_type. "
+        "If a field is missing, leave blank or use null. Text follows:\n" + first_page
+    )
+    if not api_key:
+        return {k: "" for k in fields}
+    try:
+        import openai
+
+        resp = openai.chat.completions.create(
+            model=model or llm_model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+            max_tokens=384,
+        )
+        txt = resp.choices[0].message.content.strip()
+        if txt.startswith("```"):
+            txt = txt.strip("` \n")
+            txt = txt[4:].strip() if txt.startswith("json") else txt
+        result = json.loads(txt)
+        return {k: result.get(k, "") for k in fields}
+    except Exception:
+        return {k: "" for k in fields}

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,104 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+import types
+import sys
+import extraction
+
+
+class TestNormalization(unittest.TestCase):
+    def test_normalize_doi(self):
+        assert extraction.normalize_doi("https://doi.org/10.1000/ABC") == "10.1000/abc"
+        assert extraction.normalize_doi("10.1000/xyz") == "10.1000/xyz"
+
+    def test_clean_str(self):
+        assert extraction.clean_str("A B,C!") == "abc"
+
+    def test_approx_match(self):
+        assert extraction.approx_match("https://doi.org/10.1/AAA", "10.1/aaa", "doi")
+        assert not extraction.approx_match("10.1/aaa", "10.1/bbb", "doi")
+        assert extraction.approx_match("A;B", "B a", "author_keywords")
+        assert extraction.approx_match("Title One", "titleone", "title")
+
+
+class TestCrossref(unittest.TestCase):
+    @patch("extraction.requests")
+    def test_extract_crossref_full(self, mock_requests):
+        response = {
+            "message": {
+                "DOI": "10.1234/test",
+                "title": ["Test Paper"],
+                "author": [{"family": "Doe", "given": "John", "affiliation": [{"name": "USA"}]}],
+                "issued": {"date-parts": [[2024]]},
+                "subject": ["Nursing"],
+                "container-title": ["Journal of Tests"],
+                "type": "journal-article",
+            }
+        }
+        mock_requests.get.return_value.json.return_value = response
+        meta = extraction.extract_crossref_full("10.1234/test")
+        mock_requests.get.assert_called_with("https://api.crossref.org/works/10.1234/test")
+        assert meta["doi"] == "10.1234/test"
+        assert meta["title"] == "Test Paper"
+        assert meta["author"] == "Doe, John"
+        assert meta["year"] == "2024"
+        assert meta["author_keywords"] == "Nursing"
+        assert meta["source_journal"] == "Journal of Tests"
+        assert meta["study_type"] == "journal-article"
+        assert meta["country"] == "USA"
+
+
+class TestOpenAlex(unittest.TestCase):
+    @patch("extraction.requests")
+    def test_extract_openalex_full(self, mock_requests):
+        response = {
+            "doi": "https://doi.org/10.1234/test",
+            "title": "Test Paper",
+            "authorships": [{"author": {"display_name": "John Doe"}, "institutions": [{"country_code": "US"}]}],
+            "publication_year": 2024,
+            "keywords": ["nursing"],
+            "host_venue": {"display_name": "Journal of Tests"},
+            "type": "journal-article",
+        }
+        mock_requests.get.return_value.json.return_value = response
+        meta = extraction.extract_openalex_full("10.1234/test")
+        mock_requests.get.assert_called_with(
+            "https://api.openalex.org/works/https://doi.org/10.1234/test"
+        )
+        assert meta["doi"] == "10.1234/test"
+        assert meta["title"] == "Test Paper"
+        assert meta["author"] == "John Doe"
+        assert meta["year"] == "2024"
+        assert meta["author_keywords"] == "nursing"
+        assert meta["source_journal"] == "Journal of Tests"
+        assert meta["study_type"] == "journal-article"
+        assert meta["country"] == "US"
+
+
+class TestOpenAI(unittest.TestCase):
+    def _mock_openai(self, content):
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock(message=MagicMock(content=content))]
+        return types.SimpleNamespace(chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=MagicMock(return_value=mock_resp))))
+
+    def test_extract_ai_llm_doi_only(self):
+        mock_openai = self._mock_openai('{"doi":"10.1234/test"}')
+        with patch.dict(sys.modules, {"openai": mock_openai}):
+            result = extraction.extract_ai_llm_doi_only("some text", api_key="key")
+        assert result == "10.1234/test"
+
+    def test_extract_ai_llm_full(self):
+        payload = {
+            "title": "Test Paper",
+            "author": "Doe, John",
+            "year": "2024",
+            "doi": "10.1234/test",
+            "author_keywords": "nursing",
+            "country": "US",
+            "source_journal": "Journal of Tests",
+            "study_type": "journal-article",
+        }
+        mock_openai = self._mock_openai(json.dumps(payload))
+        with patch.dict(sys.modules, {"openai": mock_openai}):
+            meta = extraction.extract_ai_llm_full("text", api_key="key")
+        assert meta == payload


### PR DESCRIPTION
## Summary
- add `extraction.py` with helper and extraction functions
- provide unit tests covering normalization, CrossRef/OpenAlex parsers, and OpenAI LLM logic

## Testing
- `python3 -m unittest -v tests.test_extraction`