### PR TITLE
Fix load_config encoding

### DIFF
--- a/ai_nurse_scr/pipeline.py
+++ b/ai_nurse_scr/pipeline.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 def load_config(path: str) -> dict:
     """Load JSON configuration from path."""
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 


### PR DESCRIPTION
## Summary
- open config files with utf-8 encoding in pipeline

## Testing
- `python3 -m unittest discover -s tests`