### PR TITLE
Centralize DOI normalization

### DIFF
--- a/ai_nurse_scr/extraction.py
+++ b/ai_nurse_scr/extraction.py
@@ -1,5 +1,6 @@
 import os
 import json
+from .utils import normalize_doi
 try:
     import requests
 except Exception:  # pragma: no cover - optional dependency
@@ -12,15 +13,6 @@ fields = [
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
 llm_model = "gpt-4"
-
-
-def normalize_doi(doi: str) -> str:
-    if not doi:
-        return ""
-    doi = str(doi).strip().lower()
-    if doi.startswith("https://doi.org/"):
-        doi = doi[len("https://doi.org/"):]
-    return doi
 
 
 def clean_str(txt: str) -> str:

--- a/ai_nurse_scr/paperqa2/utils.py
+++ b/ai_nurse_scr/paperqa2/utils.py
@@ -1,6 +1,6 @@
 import hashlib
-import re
 from pathlib import Path
+from ..utils import normalize_doi
 
 
 def sha256_file(path: str | Path) -> str:
@@ -12,9 +12,3 @@ def sha256_file(path: str | Path) -> str:
     return h.hexdigest()
 
 
-def normalize_doi(doi: str) -> str:
-    """Normalize a DOI string by removing URL prefixes and whitespace."""
-    doi = doi.strip()
-    doi = doi.lower()
-    doi = re.sub(r'^https?://(dx\.)?doi\.org/', '', doi)
-    return doi

--- a/ai_nurse_scr/utils.py
+++ b/ai_nurse_scr/utils.py
@@ -23,12 +23,18 @@ def pdf_hash_id(pdf_path, length=8):
     return f"paper_ID_{h}"
 
 
-def normalize_doi(x):
-    """Normalize DOI strings into a canonical form."""
+def normalize_doi(x: str | None) -> str:
+    """Return a canonical DOI string.
+
+    This helper removes leading ``https://doi.org/`` (or ``http://dx.doi.org``)
+    prefixes, strips whitespace and normalizes the case to lower. Passing
+    ``None`` or a non-string value returns an empty string.
+    """
     if not x or not isinstance(x, str):
         return ""
-    x = x.strip().lower().replace(" ", "")
+    x = x.strip().lower()
     x = re.sub(r"^(https?://(dx\.)?doi\.org/)", "", x)
+    x = x.replace(" ", "")
     x = re.sub(r"\s", "", x)
     return x
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -3,13 +3,13 @@ import unittest
 from unittest.mock import patch, MagicMock
 import types
 import sys
-from ai_nurse_scr import extraction
+from ai_nurse_scr import extraction, utils
 
 
 class TestNormalization(unittest.TestCase):
     def test_normalize_doi(self):
-        assert extraction.normalize_doi("https://doi.org/10.1000/ABC") == "10.1000/abc"
-        assert extraction.normalize_doi("10.1000/xyz") == "10.1000/xyz"
+        assert utils.normalize_doi("https://doi.org/10.1000/ABC") == "10.1000/abc"
+        assert utils.normalize_doi("10.1000/xyz") == "10.1000/xyz"
 
     def test_clean_str(self):
         assert extraction.clean_str("A B,C!") == "abc"


### PR DESCRIPTION
## Summary
- move DOI normalization into shared module
- update extraction code to use shared function
- update paperqa2 utils to import canonical DOI helper
- adjust tests to use shared normalize_doi

## Testing
- `python -m unittest discover -s tests -v`