### PR TITLE
Improve docstrings for pipeline modules

### DIFF
--- a/ai_nurse_scr/paperqa2/extract/crossref.py
+++ b/ai_nurse_scr/paperqa2/extract/crossref.py
@@ -2,7 +2,18 @@ from ... import extraction
 
 
 def extract_crossref(doi: str) -> dict:
-    """Retrieve Crossref metadata for a DOI."""
+    """Retrieve Crossref metadata for a DOI.
+
+    Parameters
+    ----------
+    doi:
+        DOI to query in the Crossref API.
+
+    Returns
+    -------
+    dict
+        Mapping of metadata fields returned by Crossref.
+    """
     try:
         return extraction.extract_crossref_full(doi)
     except Exception:

--- a/ai_nurse_scr/paperqa2/extract/grobid.py
+++ b/ai_nurse_scr/paperqa2/extract/grobid.py
@@ -4,7 +4,18 @@ from ...utils import check_grobid_healthy
 
 
 def extract_grobid(pdf_path: str | Path) -> dict:
-    """Call a local GROBID service to extract header information."""
+    """Call a local GROBID service to extract header information.
+
+    Parameters
+    ----------
+    pdf_path:
+        Path to the PDF file processed by GROBID.
+
+    Returns
+    -------
+    dict
+        A dictionary containing ``grobid_xml`` if successful, otherwise empty.
+    """
     if not check_grobid_healthy():
         return {}
     try:

--- a/ai_nurse_scr/paperqa2/extract/llm.py
+++ b/ai_nurse_scr/paperqa2/extract/llm.py
@@ -2,7 +2,18 @@ from ... import extraction
 
 
 def extract_llm(data: dict) -> dict:
-    """Use an LLM to fill missing metadata fields from the first page."""
+    """Use an LLM to fill missing metadata fields from the first page.
+
+    Parameters
+    ----------
+    data:
+        Dictionary that should contain ``raw_first_page`` text.
+
+    Returns
+    -------
+    dict
+        Metadata dictionary from the language model.
+    """
     text = data.get("raw_first_page", "")
     try:
         return extraction.extract_ai_llm_full(text)

--- a/ai_nurse_scr/paperqa2/extract/openalex.py
+++ b/ai_nurse_scr/paperqa2/extract/openalex.py
@@ -2,7 +2,18 @@ from ... import extraction
 
 
 def extract_openalex(doi: str) -> dict:
-    """Retrieve OpenAlex metadata for a DOI."""
+    """Retrieve OpenAlex metadata for a DOI.
+
+    Parameters
+    ----------
+    doi:
+        DOI used to request metadata from OpenAlex.
+
+    Returns
+    -------
+    dict
+        Metadata dictionary populated from the API response.
+    """
     try:
         return extraction.extract_openalex_full(doi)
     except Exception:

--- a/ai_nurse_scr/paperqa2/extract/pdfmeta.py
+++ b/ai_nurse_scr/paperqa2/extract/pdfmeta.py
@@ -4,7 +4,18 @@ from ... import extraction
 
 
 def extract_pdfmeta(pdf_path: str | Path) -> dict:
-    """Extract initial metadata from the first page of a PDF."""
+    """Extract initial metadata from the first page of a PDF.
+
+    Parameters
+    ----------
+    pdf_path:
+        Path to the PDF file.
+
+    Returns
+    -------
+    dict
+        Metadata returned by the LLM along with ``raw_first_page`` text.
+    """
     pdf_path = Path(pdf_path)
     try:
         import pdfplumber

--- a/ai_nurse_scr/paperqa2/pipeline.py
+++ b/ai_nurse_scr/paperqa2/pipeline.py
@@ -9,7 +9,18 @@ from .extract.llm import extract_llm
 
 
 def run_pipeline(pdf_path: str | Path) -> dict:
-    """Run the full extraction pipeline on a PDF."""
+    """Run the full extraction pipeline on a PDF.
+
+    Parameters
+    ----------
+    pdf_path:
+        Path to the PDF file to process.
+
+    Returns
+    -------
+    dict
+        Combined metadata extracted from all stages of the pipeline.
+    """
     pdf_path = Path(pdf_path)
     result = {
         "sha256": sha256_file(pdf_path),

--- a/ai_nurse_scr/paperqa2/utils.py
+++ b/ai_nurse_scr/paperqa2/utils.py
@@ -4,7 +4,18 @@ from ..utils import normalize_doi
 
 
 def sha256_file(path: str | Path) -> str:
-    """Compute the sha256 hex digest of a file."""
+    """Compute the SHA-256 hex digest of a file.
+
+    Parameters
+    ----------
+    path:
+        File path whose contents will be hashed.
+
+    Returns
+    -------
+    str
+        Hexadecimal SHA-256 digest string.
+    """
     h = hashlib.sha256()
     with open(path, 'rb') as f:
         for chunk in iter(lambda: f.read(8192), b''):

--- a/ai_nurse_scr/pipeline.py
+++ b/ai_nurse_scr/pipeline.py
@@ -4,18 +4,51 @@ from . import extraction
 
 
 def load_config(path: str) -> dict:
-    """Load JSON configuration from path."""
-    with open(path, 'r', encoding='utf-8') as f:
+    """Load a pipeline configuration file.
+
+    Parameters
+    ----------
+    path:
+        Path to a JSON file containing configuration options.
+
+    Returns
+    -------
+    dict
+        Dictionary with the parsed configuration values.
+    """
+    with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
 
 
 def find_pdfs(directory: str):
-    """Yield PDF files within the directory."""
-    return sorted(Path(directory).glob('*.pdf'))
+    """Return a list of PDFs under ``directory``.
+
+    Parameters
+    ----------
+    directory:
+        Directory to search for ``.pdf`` files.
+
+    Returns
+    -------
+    list[Path]
+        Sorted list of PDF paths found.
+    """
+    return sorted(Path(directory).glob("*.pdf"))
 
 
 def extract_text(pdf_path: Path) -> str:
-    """Return all text from a PDF using ``pdfplumber``."""
+    """Extract raw text from a PDF file.
+
+    Parameters
+    ----------
+    pdf_path:
+        Path to the PDF document.
+
+    Returns
+    -------
+    str
+        Concatenated text of all pages or an empty string on error.
+    """
     try:
         import pdfplumber
     except Exception:
@@ -28,7 +61,18 @@ def extract_text(pdf_path: Path) -> str:
 
 
 def extract_data(text: str) -> dict:
-    """Extract structured metadata from paper text."""
+    """Extract structured metadata from paper text.
+
+    Parameters
+    ----------
+    text:
+        Plain text extracted from the PDF.
+
+    Returns
+    -------
+    dict
+        Metadata dictionary containing keys from ``extraction.fields``.
+    """
     first_chunk = text[:4000]
     meta = extraction.extract_ai_llm_full(first_chunk)
     doi = meta.get("doi", "")
@@ -41,7 +85,19 @@ def extract_data(text: str) -> dict:
 
 
 def run(config_path: str, pdf_dir: str) -> None:
-    """Run the pipeline sequentially using the given configuration and PDF directory."""
+    """Execute the CLI pipeline.
+
+    Parameters
+    ----------
+    config_path:
+        Path to a JSON configuration file.
+    pdf_dir:
+        Directory containing PDF files to process.
+
+    Returns
+    -------
+    None
+    """
     config = load_config(config_path)
     print(f"[INFO] Loaded config from {config_path}")
 


### PR DESCRIPTION
## Summary
- expand documentation for main pipeline helpers
- clarify metadata extraction helpers
- add explanations for paperqa2 helper modules

## Testing
- `python -m unittest discover tests -v`