### PR TITLE
Add helper for Colab environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,34 +57,21 @@ First create a user secret:
 1. Open **Settings → Manage user secrets** in the Colab menu.
 2. Add your OpenAI key under the name `OPENAI_API_KEY`.
 
-The snippet below mounts Drive, creates a timestamped project folder, clones
-the repository and loads the secret:
+Instead of manually mounting Drive and creating folders you can use the helper
+script in `colab_setup.py`:
 
 ```python
-from google.colab import drive, userdata
-from pathlib import Path
-import time
+import colab_setup
 
-drive.mount('/content/drive')
-timestamp = time.strftime('%y%m%d_%H%M')
-project_root = Path('/content/drive/My Drive/Pilot') / f'ScR_GitHub_v1_{timestamp}'
-project_root.mkdir(parents=True, exist_ok=True)
-%cd $project_root
-!git clone https://github.com/Nurse-David/AI-Nurse_ScR_v6.git
-%cd AI-Nurse_ScR_v6
-!pip install -r requirements.txt
-
-# Retrieve your key from Colab secrets and expose it as an env variable
-import os
-os.environ["OPENAI_API_KEY"] = userdata.get('OPENAI_API_KEY')
-
-pdf_root = Path('/content/drive/My Drive/Pilot/PDFs')
-pdf_root.mkdir(parents=True, exist_ok=True)
-
+project_root, pdf_dir = colab_setup.setup()
 ```
 
-Store your PDFs in `/content/drive/My Drive/Pilot/PDFs` and reference that
-directory when running the CLI or notebook.
+This will mount Drive (if running in Colab), create a timestamped project
+folder and set up a `PDFs` directory. The OpenAI secret stored in Colab will be
+exported as `OPENAI_API_KEY` for you.
+
+Store your PDFs in the reported `pdf_dir` and reference that directory when
+running the CLI or notebook.
 
 ## Demo Notebook
 For an interactive walkthrough open `Nurse_AI_ScR_v6_3.ipynb` in Jupyter or

--- a/colab_setup.py
+++ b/colab_setup.py
@@ -1,0 +1,72 @@
+"""Utilities for running this repository in Google Colab."""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def in_colab() -> bool:
+    """Return ``True`` when executed inside Google Colab."""
+    return "google.colab" in sys.modules
+
+
+def mount_drive() -> Path:
+    """Mount the user's Google Drive and return the mount path.
+
+    If the drive is already mounted the existing path is returned.
+    """
+    from google.colab import drive  # type: ignore
+
+    mount_path = Path("/content/drive")
+    if mount_path.exists() and any(mount_path.iterdir()):
+        return mount_path
+
+    drive.mount(str(mount_path))
+    return mount_path
+
+
+def setup(base_dir: str = "My Drive/Pilot", project_prefix: str = "ScR_GitHub_v1") -> tuple[Path, Path]:
+    """Mount Drive and create project directories under ``base_dir``.
+
+    Parameters
+    ----------
+    base_dir:
+        Directory inside ``My Drive`` used to store project files.
+    project_prefix:
+        Prefix for the timestamped project folder.
+
+    Returns
+    -------
+    tuple
+        The created ``(project_root, pdf_dir)`` paths.
+    """
+    if not in_colab():
+        print("[INFO] Not running inside Google Colab; skipping Drive setup.")
+        cwd = Path.cwd()
+        pdf_dir = cwd / "PDFs"
+        pdf_dir.mkdir(parents=True, exist_ok=True)
+        return cwd, pdf_dir
+
+    mount_path = mount_drive()
+    timestamp = time.strftime("%y%m%d_%H%M")
+    project_root = mount_path / base_dir / f"{project_prefix}_{timestamp}"
+    project_root.mkdir(parents=True, exist_ok=True)
+    os.chdir(project_root)
+
+    pdf_dir = project_root / "PDFs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        from google.colab import userdata  # type: ignore
+
+        api_key = userdata.get("OPENAI_API_KEY")
+        if api_key:
+            os.environ["OPENAI_API_KEY"] = api_key
+    except Exception:
+        pass
+
+    print(f"[INFO] Project root: {project_root}")
+    print(f"[INFO] PDF directory: {pdf_dir}")
+    return project_root, pdf_dir

--- a/notebooks/walkthrough.ipynb
+++ b/notebooks/walkthrough.ipynb
@@ -1,1 +1,43 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# paperqa2 Walkthrough\n", "\n", "This notebook demonstrates running the pipeline on a sample PDF."]}, {"cell_type": "code", "metadata": {}, "execution_count": null, "source": ["from paperqa2.pipeline import run_pipeline\n", "\n", "result = run_pipeline('sample.pdf')\n", "result"]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}}, "nbformat": 4, "nbformat_minor": 2}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# paperqa2 Walkthrough\n",
+    "\n",
+    "This notebook demonstrates running the pipeline on a sample PDF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "# Run this cell on Google Colab to mount Drive and set up directories\n",
+    "import colab_setup\n",
+    "project_root, pdf_dir = colab_setup.setup()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "from paperqa2.pipeline import run_pipeline\n",
+    "\n",
+    "result = run_pipeline('sample.pdf')\n",
+    "result"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- provide `colab_setup.py` to automate Google Colab project setup
- reference helper script in README
- show usage of helper in example notebook

## Testing
- `python -m unittest discover tests -v`