### PR TITLE
Fix metrics imports

### DIFF
--- a/ai_nurse_scr/metrics.py
+++ b/ai_nurse_scr/metrics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from typing import Iterable, Tuple, List, Dict
-
+from typing import Iterable, Tuple, List, Dict, Sequence
+from pathlib import Path
+import json, csv
 
 def _confusion(true: Iterable[bool], pred: Iterable[bool]) -> Tuple[int, int, int, int]:
     """Return (tp, tn, fp, fn) counts for boolean lists."""
@@ -45,16 +46,6 @@ def classification_metrics(true: Iterable[bool], pred: Iterable[bool]) -> Dict[s
         "f1": f1_score(tp, fp, fn),
         "accuracy": accuracy(tp, tn, fp, fn),
     }
-
-"""Utility functions for computing pipeline metrics."""
-
-from __future__ import annotations
-
-from pathlib import Path
-import json
-import csv
-from typing import Sequence
-
 
 def simple_tokenize(text: str) -> list[str]:
     """Tokenize text using whitespace splitting."""


### PR DESCRIPTION
## Summary
- remove duplicate docstring block in metrics
- consolidate imports at top of file

## Testing
- `python -m py_compile ai_nurse_scr/metrics.py`
- `python -m unittest discover tests -v` *(fails: NameError: name 'tempfile' is not defined; AttributeError: 'dict' object has no attribute 'extra'; NameError: metrics)*