### PR TITLE
Update config snapshot file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See `config_example.yaml` for the minimal keys (`pdf_dir`, `run_id`) your config
 
 Running this command executes the full extraction pipeline and writes a
 JSONL file of metadata to the configured output directory. Each run also
-creates a `config_snapshot.yaml` in the same directory capturing the loaded
+creates a `config_snapshot.json` in the same directory capturing the loaded
 configuration along with the current package version and git commit hash.
 
 ## Running in Google Colab

--- a/ai_nurse_scr/pipeline.py
+++ b/ai_nurse_scr/pipeline.py
@@ -87,7 +87,9 @@ def run(config_path: str, pdf_dir: str) -> None:
         commit = "unknown"
     snapshot["commit"] = commit
 
-    with open(out_dir / "config_snapshot.yaml", "w", encoding="utf-8") as f:
+    # Store a snapshot of the loaded configuration for reproducibility
+    # Use a JSON extension to match the file contents
+    with open(out_dir / "config_snapshot.json", "w", encoding="utf-8") as f:
         json.dump(snapshot, f, ensure_ascii=False, indent=2)
 
         

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -74,7 +74,7 @@ class TestPipelineHelpers(unittest.TestCase):
             metrics_dir = Path('outputs/metrics')
             summary = metrics_dir / 'summary.csv'
             self.assertTrue(summary.exists())
-            snapshot = Path(td) / 'config_snapshot.yaml'
+            snapshot = Path(td) / 'config_snapshot.json'
             self.assertTrue(snapshot.exists())
             with open(snapshot) as sf:
                 snap = json.load(sf)


### PR DESCRIPTION
## Summary
- save pipeline config snapshot as `config_snapshot.json`
- update tests and README to expect the new filename

## Testing
- `python -m unittest discover tests -v`