### PR TITLE
Fix PDF directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ configuration along with the current package version and git commit hash.
 2. Add a secret named `OPENAI_API_KEY` containing your key.
 
 ### 4. Mount Drive and create folders
-Use `colab_setup.setup()` to mount Google Drive (if running in Colab) and create a timestamped project directory with a `PDFs` folder. The function also loads the secret `OPENAI_API_KEY` into the environment for you.
+Use `colab_setup.setup()` to mount Google Drive (if running in Colab) and create a timestamped project directory. The `PDFs` folder is now placed directly under the `Pilot` directory. The function also loads the secret `OPENAI_API_KEY` into the environment for you.
 
 ```python
 import colab_setup

--- a/colab_setup.py
+++ b/colab_setup.py
@@ -55,7 +55,7 @@ def setup(base_dir: str = "My Drive/Pilot", project_prefix: str = "ScR_GitHub_v1
     project_root.mkdir(parents=True, exist_ok=True)
     os.chdir(project_root)
 
-    pdf_dir = project_root / "PDFs"
+    pdf_dir = mount_path / base_dir / "PDFs"
     pdf_dir.mkdir(parents=True, exist_ok=True)
 
     try:


### PR DESCRIPTION
## Summary
- return a shared `PDFs` folder under the Pilot directory when running `colab_setup.setup`
- clarify updated behaviour in the README

## Testing
- `python -m unittest discover tests -v`