### PR TITLE
Fix packaging to include module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,9 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["ai_nurse_scr*"]
+
 [project.scripts]
 ai-nurse-scr = "ai_nurse_scr.cli:main"


### PR DESCRIPTION
## Summary
- include `ai_nurse_scr` package when building from `pyproject.toml`

## Testing
- `python -m unittest discover tests -v`