### PR TITLE
Fix dependency check for PyYAML

### DIFF
--- a/ai_nurse_scr/setup.py
+++ b/ai_nurse_scr/setup.py
@@ -14,7 +14,12 @@ def install_dependencies() -> None:
             pkg = line.strip().split("==")[0]
             if not pkg:
                 continue
-            module = "fitz" if pkg == "pymupdf" else pkg.replace("-", "_")
+            if pkg == "pymupdf":
+                module = "fitz"
+            elif pkg == "pyyaml":
+                module = "yaml"
+            else:
+                module = pkg.replace("-", "_")
             try:
                 importlib.import_module(module)
             except Exception:


### PR DESCRIPTION
## Summary
- add special-case mapping for PyYAML in `install_dependencies`
- run unit tests

## Testing
- `python -m unittest discover tests -v`